### PR TITLE
Add `DeserializeSeed` support

### DIFF
--- a/src/dds/no_key/datareader.rs
+++ b/src/dds/no_key/datareader.rs
@@ -6,6 +6,7 @@ use std::{
 
 use mio_06::{self, Evented};
 use futures::stream::{FusedStream, Stream};
+use serde::Deserialize;
 
 use crate::{
   dds::{
@@ -71,7 +72,13 @@ where
       keyed_datareader: keyed,
     }
   }
+}
 
+impl<'de, D: 'static, DA> DataReader<D, DA>
+where
+  DA: DeserializerAdapter<D>,
+  DA::Input: Deserialize<'de>,
+{
   /// Reads amount of samples found with `max_samples` and `read_condition`
   /// parameters.
   ///
@@ -580,10 +587,11 @@ where
 {
 }
 
-impl<D, DA> Stream for DataReaderStream<D, DA>
+impl<'de, D, DA> Stream for DataReaderStream<D, DA>
 where
   D: 'static,
   DA: DeserializerAdapter<D>,
+  DA::Input: Deserialize<'de>,
 {
   type Item = ReadResult<D>;
 
@@ -599,10 +607,11 @@ where
   }
 }
 
-impl<D, DA> FusedStream for DataReaderStream<D, DA>
+impl<'de, D, DA> FusedStream for DataReaderStream<D, DA>
 where
   D: 'static,
   DA: DeserializerAdapter<D>,
+  DA::Input: Deserialize<'de>,
 {
   fn is_terminated(&self) -> bool {
     false // Never terminate. This means it is always valid to call poll_next().

--- a/src/dds/no_key/simpledatareader.rs
+++ b/src/dds/no_key/simpledatareader.rs
@@ -5,6 +5,7 @@ use futures::stream::{FusedStream, Stream, StreamExt};
 use log::{debug, error, info, trace, warn};
 use mio_06::{self, Evented};
 use mio_08;
+use serde::Deserialize;
 
 use crate::{
   dds::{
@@ -49,7 +50,10 @@ where
     self.keyed_simpledatareader.drain_read_notifications();
   }
 
-  pub fn try_take_one(&self) -> ReadResult<Option<DeserializedCacheChange<D>>> {
+  pub fn try_take_one<'de>(&self) -> ReadResult<Option<DeserializedCacheChange<D>>>
+  where
+    DA::Input: Deserialize<'de>,
+  {
     match self.keyed_simpledatareader.try_take_one() {
       Err(e) => Err(e),
       Ok(None) => Ok(None),
@@ -68,9 +72,12 @@ where
     self.keyed_simpledatareader.guid()
   }
 
-  pub fn as_async_stream(
+  pub fn as_async_stream<'de>(
     &self,
-  ) -> impl Stream<Item = ReadResult<DeserializedCacheChange<D>>> + FusedStream + '_ {
+  ) -> impl Stream<Item = ReadResult<DeserializedCacheChange<D>>> + FusedStream + '_
+  where
+    DA::Input: Deserialize<'de>,
+  {
     self
       .keyed_simpledatareader
       .as_async_stream()

--- a/src/dds/with_key/datawriter.rs
+++ b/src/dds/with_key/datawriter.rs
@@ -1274,6 +1274,7 @@ mod tests {
     serialization::cdr_serializer::CDRSerializerAdapter,
     structure::topic_kind::TopicKind,
     test::random_data::*,
+    Key,
   };
 
   #[test]

--- a/src/dds/with_key/datawriter.rs
+++ b/src/dds/with_key/datawriter.rs
@@ -1274,7 +1274,6 @@ mod tests {
     serialization::cdr_serializer::CDRSerializerAdapter,
     structure::topic_kind::TopicKind,
     test::random_data::*,
-    Key,
   };
 
   #[test]

--- a/src/serialization.rs
+++ b/src/serialization.rs
@@ -8,7 +8,9 @@ pub mod representation_identifier;
 pub(crate) mod pl_cdr_adapters;
 
 // public exports
-pub use cdr_serializer::{to_writer_endian, CDRSerializerAdapter, CdrSerializer};
+pub use cdr_serializer::{
+  to_writer_endian, CDRSerializerAdapter, CdrSerializer, Error as CdrSerializerError,
+};
 pub use cdr_deserializer::{deserialize_from_cdr, CDRDeserializerAdapter, CdrDeserializer};
 pub use byteorder::{BigEndian, LittleEndian};
 pub use error::{Error, Result};

--- a/src/serialization/cdr_deserializer.rs
+++ b/src/serialization/cdr_deserializer.rs
@@ -36,13 +36,21 @@ where
   D: DeserializeOwned,
 {
   type Error = Error;
+  type Input = D;
 
   fn supported_encodings() -> &'static [RepresentationIdentifier] {
     &REPR_IDS
   }
 
-  fn from_bytes(input_bytes: &[u8], encoding: RepresentationIdentifier) -> Result<D> {
-    deserialize_from_cdr(input_bytes, encoding).map(|(d, _size)| d)
+  fn from_bytes_seed<'de, S>(
+    input_bytes: &[u8],
+    encoding: RepresentationIdentifier,
+    seed: S,
+  ) -> std::result::Result<D, Self::Error>
+  where
+    S: DeserializeSeed<'de, Value = Self::Input>,
+  {
+    deserialize_from_cdr_seed(input_bytes, encoding, seed).map(|(d, _size)| d)
   }
 }
 
@@ -181,6 +189,34 @@ where
 
     repr_id => Err(Error::NotSupported(format!(
       "Unknown serialization format. requested={:?}.",
+      repr_id
+    ))),
+  }
+}
+
+pub fn deserialize_from_cdr_seed<'de, S>(
+  input_bytes: &[u8],
+  encoding: RepresentationIdentifier,
+  seed: S,
+) -> Result<(<S as DeserializeSeed<'de>>::Value, usize)>
+where
+  S: DeserializeSeed<'de>,
+{
+  match encoding {
+    RepresentationIdentifier::CDR_LE | RepresentationIdentifier::PL_CDR_LE => {
+      let mut deserializer = CdrDeserializer::<LittleEndian>::new(input_bytes);
+      let t = seed.deserialize(&mut deserializer)?;
+      Ok((t, deserializer.serialized_data_count))
+    }
+
+    RepresentationIdentifier::CDR_BE | RepresentationIdentifier::PL_CDR_BE => {
+      let mut deserializer = CdrDeserializer::<BigEndian>::new(input_bytes);
+      let t = seed.deserialize(&mut deserializer)?;
+      Ok((t, deserializer.serialized_data_count))
+    }
+
+    repr_id => Err(Error::NotSupported(format!(
+      "Unknown representaiton identifier {:?}.",
       repr_id
     ))),
   }

--- a/src/serialization/cdr_deserializer.rs
+++ b/src/serialization/cdr_deserializer.rs
@@ -31,10 +31,7 @@ const REPR_IDS: [RepresentationIdentifier; 3] = [
   RepresentationIdentifier::PL_CDR_LE,
 ];
 
-impl<D> no_key::DeserializerAdapter<D> for CDRDeserializerAdapter<D>
-where
-  D: DeserializeOwned,
-{
+impl<D> no_key::DeserializerAdapter<D> for CDRDeserializerAdapter<D> {
   type Error = Error;
   type Input = D;
 
@@ -56,7 +53,7 @@ where
 
 impl<D> with_key::DeserializerAdapter<D> for CDRDeserializerAdapter<D>
 where
-  D: Keyed + DeserializeOwned,
+  D: Keyed,
   <D as Keyed>::K: DeserializeOwned, // Key should do this already?
 {
   fn key_from_bytes(input_bytes: &[u8], encoding: RepresentationIdentifier) -> Result<D::K> {

--- a/src/serialization/pl_cdr_adapters.rs
+++ b/src/serialization/pl_cdr_adapters.rs
@@ -2,6 +2,7 @@ use std::marker::PhantomData;
 
 use bytes::Bytes;
 use byteorder::{ByteOrder, LittleEndian};
+use serde::Deserialize;
 
 use crate::{
   dds::adapters::{no_key, with_key},
@@ -107,12 +108,19 @@ where
   D: PlCdrDeserialize,
 {
   type Error = PlCdrDeserializeError;
+  type Input = D;
 
   fn supported_encodings() -> &'static [RepresentationIdentifier] {
     &REPR_IDS
   }
 
-  fn from_bytes(input_bytes: &[u8], encoding: RepresentationIdentifier) -> Result<D, Self::Error> {
+  fn from_bytes<'de>(
+    input_bytes: &[u8],
+    encoding: RepresentationIdentifier,
+  ) -> Result<D, Self::Error>
+  where
+    Self::Input: Deserialize<'de>,
+  {
     match encoding {
       RepresentationIdentifier::PL_CDR_LE | RepresentationIdentifier::PL_CDR_BE => {
         D::from_pl_cdr_bytes(input_bytes, encoding)
@@ -122,6 +130,17 @@ where
         repr_id
       ))),
     }
+  }
+
+  fn from_bytes_seed<'de, S>(
+    _input_bytes: &[u8],
+    _encoding: RepresentationIdentifier,
+    _seed: S,
+  ) -> Result<D, Self::Error>
+  where
+    S: serde::de::DeserializeSeed<'de, Value = Self::Input>,
+  {
+    unimplemented!()
   }
 }
 

--- a/src/serialization/pl_cdr_adapters.rs
+++ b/src/serialization/pl_cdr_adapters.rs
@@ -2,7 +2,6 @@ use std::marker::PhantomData;
 
 use bytes::Bytes;
 use byteorder::{ByteOrder, LittleEndian};
-use serde::Deserialize;
 
 use crate::{
   dds::adapters::{no_key, with_key},
@@ -114,12 +113,13 @@ where
     &REPR_IDS
   }
 
-  fn from_bytes<'de>(
+  fn from_bytes_seed<'de, S>(
     input_bytes: &[u8],
     encoding: RepresentationIdentifier,
+    _seed: S,
   ) -> Result<D, Self::Error>
   where
-    Self::Input: Deserialize<'de>,
+    S: serde::de::DeserializeSeed<'de, Value = Self::Input>,
   {
     match encoding {
       RepresentationIdentifier::PL_CDR_LE | RepresentationIdentifier::PL_CDR_BE => {
@@ -130,17 +130,6 @@ where
         repr_id
       ))),
     }
-  }
-
-  fn from_bytes_seed<'de, S>(
-    _input_bytes: &[u8],
-    _encoding: RepresentationIdentifier,
-    _seed: S,
-  ) -> Result<D, Self::Error>
-  where
-    S: serde::de::DeserializeSeed<'de, Value = Self::Input>,
-  {
-    unimplemented!()
   }
 }
 


### PR DESCRIPTION
To allow guided CDR deserialization using runtime type information. This is useful when the message types are not yet known at compile time.

We keep this as a draft for know until https://github.com/jhelovuo/RustDDS/pull/291 is merged.